### PR TITLE
Feat[be]: Fix trouble creation error by adding log_id column to TroubleLog model

### DIFF
--- a/server/app/core/config/elastic_config.py
+++ b/server/app/core/config/elastic_config.py
@@ -295,6 +295,18 @@ ELASTIC_MAPPINGS = {
           }
         }
       },
+        "message_timestamp": {
+        "type": "date"
+      },
+      "log_level": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
       "vector": {
         "type": "dense_vector",
         "dims": 1536,

--- a/server/app/infra/database/elaticsearch.py
+++ b/server/app/infra/database/elaticsearch.py
@@ -71,9 +71,9 @@ class ElasticsearchClient:
         query = {"query": {"ids": {"values": ids}}}
         return self._execute_search(index, query)
     
-    def search_by_datetime(self, index: str, start_time: str, end_time: str) -> List[Any]:
+    def search_by_datetime(self, index: str, time_filter: Dict[str, Any]) -> List[Any]:
         """ 시간 범위로 검색하는 함수 """
-        query = {"query": {"range": {"@timestamp": {"gte": start_time, "lte": end_time}}}}
+        query = {"query": {"range": time_filter}}
         return self._execute_search(index, query)
 
     def search_by_terms(self, index: str, term_field: str, term_values: List[Any]) -> List[Dict[str, Any]]:

--- a/server/app/models/trouble_log.py
+++ b/server/app/models/trouble_log.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, ForeignKey
+from sqlalchemy import Column, Integer, ForeignKey, String
 from sqlalchemy.orm import relationship
 from app.infra.database.session import Base
 
@@ -8,6 +8,6 @@ class TroubleLog(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     trouble_id = Column(Integer, ForeignKey("troubles.id"), nullable=False)
-
+    log_id = Column(String(100), nullable=False)
     # Relationships
     trouble = relationship("Trouble", back_populates="logs")

--- a/server/app/repositories/elasticsearch.py
+++ b/server/app/repositories/elasticsearch.py
@@ -38,7 +38,7 @@ def retrieve_log(
         category_filter = {"category": category}
     time_filter = None
     if start_time and end_time:
-        time_filter = {"@timestamp": {"gte": start_time, "lte": end_time}}
+        time_filter = {"message_timestamp": {"gte": start_time, "lte": end_time}}
     search_by_hybrid = es.search_by_vector(
         index=index_name,
         query=query,
@@ -70,7 +70,8 @@ def get_logs_by_ids(index_name: str, ids: List[str]) -> List[Dict[str, Any]]:
 def get_logs_by_datetime(index_name: str, start_time: str, end_time: str):
     """시간 범위로 로그를 검색하는 함수"""
     try:
-        results = es.search_by_datetime(index=index_name, start_time=start_time, end_time=end_time)
+        time_filter = {"message_timestamp": {"gte": start_time, "lte": end_time}}
+        results = es.search_by_datetime(index=index_name, time_filter=time_filter)
         if not results:
             raise HTTPException(status_code=404, detail="No logs found with the provided datetime range.")
         return results

--- a/server/app/services/pipeline.py
+++ b/server/app/services/pipeline.py
@@ -10,6 +10,8 @@ from app.core.config.settings import get_settings
 from app.infra.database.elaticsearch import ElasticsearchClient
 from app.core.llm.prompts import LOG_COMMENT_TEMPLATE, AIMessage
 
+from app.core.utils import log_utils as LogUtils
+
 
 class FromDB:
     """데이터베이스에서 가져올 데이터 정의 클래스"""
@@ -33,15 +35,17 @@ class PipelineService:
         # 데이터베이스에서 유저 설정 카테고리, 언어, 인덱스 정보를 가져옴
         from_db = FromDB() 
         log_message = log_data.get("message", "")
-        ai_msg = self.gen_ai_msg(log_message, from_db.category_list, from_db.language)
+        ai_msg = self._gen_ai_msg(log_message, from_db.category_list, from_db.language)
         # ai_msg = AIMessage(
         #     comment="유저가 비밀번호를 잘못 입력했습니다.",
         #     category="유저 입력 에러"
         # )
-        vector = self.embed_comment(ai_msg.comment)
+        vector = self._embed_comment(ai_msg.comment)
         log_data["comment"] = ai_msg.comment
         log_data["category"] = ai_msg.category
         log_data["vector"] = vector
+        log_data["message_timestamp"] = LogUtils.extract_timestamp_from_message(log_message)
+        log_data["log_level"] = LogUtils.extract_log_level(log_message)
         
         # elasticsearch에 저장
         body = log_data
@@ -50,7 +54,7 @@ class PipelineService:
 
         return log_data
     
-    def gen_ai_msg(self, log_msg: str, category_list: list, language: Language):
+    def _gen_ai_msg(self, log_msg: str, category_list: list, language: Language):
         '''
         로그 메세지에 대한 코멘트를 생성하는 함수
         '''
@@ -64,7 +68,7 @@ class PipelineService:
         chain = comment_model.with_structured_output(AIMessage)
         return chain.invoke([HumanMessage(content=formatted_prompt)])
 
-    def embed_comment(self, comment: str):
+    def _embed_comment(self, comment: str):
         '''
         코멘트를 임베딩하는 함수
         '''


### PR DESCRIPTION
# 변경사항

## 1. TroubleLog 모델에 log_id 컬럼 추가
trouble 생성 시 발생하던 TypeError: 'log_id' is an invalid keyword argument for TroubleLog 오류를 해결하기 위해 TroubleLog 모델에 누락된 log_id 컬럼을 추가하였습니다.

## 2. 원본 메세지 타임스탬프 활용 검색
원본 메세지의 타임스탬프를 활용하여 elasticsearch repository에서 사용하도록 했습니다.