### PR TITLE
Feat[be]: Add host name & message attributes to response body in recent log API

### DIFF
--- a/server/app/core/utils/log_utils.py
+++ b/server/app/core/utils/log_utils.py
@@ -48,9 +48,9 @@ def extract_log_level(message: str) -> Optional[str]:
     return None
 
 
-def extract_logs(logs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def extract_basic_logs(logs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
-    로그 목록을 처리하여 타임스탬프와 로그 레벨을 추출합니다.
+    로그 목록을 처리하여 기본 정보(타임스탬프, 로그 레벨, 키워드)를 추출합니다.
 
     Args:
         logs (List[Dict[str, Any]]): 처리할 로그 목록
@@ -72,6 +72,39 @@ def extract_logs(logs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             new_log["log_level"] = log["_source"]["log_level"]
         if "keyword" in log["_source"]:
             new_log["keyword"] = log["_source"]["keyword"]
+        processed_logs.append(new_log)
+
+    return processed_logs
+
+
+def extract_full_logs(logs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    로그 목록을 처리하여 모든 정보(타임스탬프, 로그 레벨, 메시지, 호스트 이름 등)를 추출합니다.
+
+    Args:
+        logs (List[Dict[str, Any]]): 처리할 로그 목록
+
+    Returns:
+        List[Dict[str, Any]]: 처리된 로그 목록
+    """
+    if not isinstance(logs, list):
+        return []
+
+    processed_logs = []
+    for log in logs:
+        new_log = {}
+        if "_id" in log:
+            new_log["id"] = log["_id"]
+        if "message_timestamp" in log["_source"]:
+            new_log["message_timestamp"] = log["_source"]["message_timestamp"]
+        if "log_level" in log["_source"]:
+            new_log["log_level"] = log["_source"]["log_level"]
+        if "keyword" in log["_source"]:
+            new_log["keyword"] = log["_source"]["keyword"]
+        if "message" in log["_source"]:
+            new_log["message"] = log["_source"]["message"]
+        if "host" in log["_source"] and "name" in log["_source"]["host"]:
+            new_log["host_name"] = log["_source"]["host"]["name"]
         processed_logs.append(new_log)
 
     return processed_logs

--- a/server/app/services/log.py
+++ b/server/app/services/log.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 from datetime import datetime
 
 from app.core.utils.time_utils import get_start_time, get_log_time_by_count
-from app.core.utils.log_utils import extract_logs, remove_vector_from_logs
+from app.core.utils.log_utils import extract_basic_logs, extract_full_logs, remove_vector_from_logs
 from app.services.project import ProjectService
 from app.repositories import user as UserRepository
 from app.repositories import elasticsearch as ElasticsearchRepository
@@ -28,7 +28,7 @@ class LogService:
             end_time=end_time,
         )
 
-        return extract_logs(logs)
+        return extract_basic_logs(logs)
 
     def get_recent_logs(
         self,
@@ -49,7 +49,7 @@ class LogService:
             end_time=end_time,
         )
 
-        return extract_logs(logs)
+        return extract_full_logs(logs)
 
     def get_log_detail(self, project_id: int, log_ids: List[int]) -> list:
         db_project = ProjectService.get_project_by_id(self, project_id=project_id)
@@ -74,4 +74,4 @@ class LogService:
             k=k,
         )
         
-        return extract_logs(logs)
+        return extract_basic_logs(logs)


### PR DESCRIPTION
- `recent log`의 기존 response 값의 구조를 변경하였습니다. 
- 이때, 기존 함수와의 중복을 막고, 함수 목적을 살리기 위해 함수명을 변경하였습니다
> 새로운 구조 예시
> ```
> {
>     "id": "",
>     "message_timestamp": "2025-06-03T01:57:21.706000",
>     "log_level": "ERROR",
>     "keyword": "사용자 오류",
>     "message": "2025-06-03 01:57:21.706 [scheduling-1] ERROR com.makeLog.makeLog.LogInitializer - 해당하는 사용자가 존재하지 않습니다",
>     "host_name": "heejin-macbookpro.local"
>   }
> ```

