### PR TITLE
Refac[be]: Refactor trouble list endpoint and fix import error

### DIFF
--- a/server/app/api/routers/log.py
+++ b/server/app/api/routers/log.py
@@ -10,7 +10,7 @@ router = APIRouter()
 
 
 # 메인보드 로그 그래프 조회
-@router.get("/log/mainboard")
+@router.get("/logs/mainboard")
 def get_log(
     project_id: int,
     log_time: LogTimeFilter = LogTimeFilter.DAY,
@@ -21,7 +21,7 @@ def get_log(
     return service.get_logs(username, project_id, log_time, size)
 
 
-@router.get("/log/recent")
+@router.get("/logs/recent")
 def get_recent_logs(
     project_id: int,
     username: str = Depends(get_current_username),
@@ -37,7 +37,7 @@ def get_recent_logs(
     )
     
 
-@router.get("/log/search")
+@router.get("/logs/search")
 def get_logs_by_search(
     project_id: int,
     query: str,
@@ -59,7 +59,7 @@ def get_logs_by_search(
     )
 
 
-@router.get("/log/detail", response_model=List[dict])
+@router.get("/logs/detail", response_model=List[dict])
 def get_log_detail(
     project_id: int = Query(..., description="프로젝트 ID"),
     log_ids: Optional[List[str]] = Query(..., description="로그 ID 리스트"),

--- a/server/app/api/routers/pipeline.py
+++ b/server/app/api/routers/pipeline.py
@@ -9,7 +9,7 @@ router = APIRouter()
 logger = logging.getLogger("logstash")
 
 
-@router.post("/log")
+@router.post("/pipeline")
 def collect_log(
     data: dict,
     service: PipelineService = Depends(get_pipeline_service),

--- a/server/app/api/routers/project.py
+++ b/server/app/api/routers/project.py
@@ -15,7 +15,7 @@ from app.services.project import ProjectService
 router = APIRouter()
 
 
-@router.post("/project", response_model=Project)
+@router.post("/projects", response_model=Project)
 def create_projects(
     project_dto: ProjectCreate,
     service: ProjectService = Depends(get_project_service),
@@ -24,7 +24,7 @@ def create_projects(
     return service.create_project(project_dto=project_dto, username=username)
 
 
-@router.post("/project/invite")
+@router.post("/projects/invite")
 def join_project_by_invite(
     invite_dto: ProjectInvite,
     service: ProjectService = Depends(get_project_service),
@@ -33,7 +33,7 @@ def join_project_by_invite(
     return service.join_project_by_invite(invite_dto=invite_dto, username=username)
 
 
-@router.get("/project", response_model=list[Project])
+@router.get("/projects", response_model=list[Project])
 def get_project(
     service: ProjectService = Depends(get_project_service),
     username: str = Depends(get_current_username),
@@ -41,14 +41,14 @@ def get_project(
     return service.get_projects_by_user(username=username)
 
 
-@router.get("/project/{project_id}/keyword", response_model=ProjectKeywordsBase)
+@router.get("/projects/{project_id}/keywords", response_model=ProjectKeywordsBase)
 def get_project_keyword(
     project_id: int, service: ProjectService = Depends(get_project_service)
 ):
     return service.get_project_keywords(project_id=project_id)
 
 
-@router.patch("/project/{project_id}/keywords", response_model=ProjectKeywordsUpdate)
+@router.patch("/projects/{project_id}/keywords", response_model=ProjectKeywordsUpdate)
 def update_project_keyword(
     project_id: int,
     keywords_update: ProjectKeywordsUpdate,
@@ -61,7 +61,7 @@ def update_project_keyword(
     return updated_project
 
 
-@router.delete("/project/{project_id}")
+@router.delete("/projects/{project_id}")
 def delete_project(
     project_id: int,
     service: ProjectService = Depends(get_project_service),
@@ -70,7 +70,7 @@ def delete_project(
     return service.delete_project(project_id=project_id, username=username)
 
 
-@router.get("/project/{project_id}/invite-code")
+@router.get("/projects/{project_id}/invite-code")
 def get_project_invite_code(
     project_id: int,
     service: ProjectService = Depends(get_project_service),
@@ -79,7 +79,7 @@ def get_project_invite_code(
     return service.get_project_invite_code(project_id=project_id, username=username)
 
 
-@router.get("/project/{project_id}/members", response_model=list[ProjectMembers])
+@router.get("/projects/{project_id}/members", response_model=list[ProjectMembers])
 def get_project_members(
     project_id: int,
     service: ProjectService = Depends(get_project_service),
@@ -88,7 +88,7 @@ def get_project_members(
     return service.get_project_members(project_id=project_id, username=username)
 
 
-@router.patch("/project/{project_id}/role")
+@router.patch("/projects/{project_id}/role")
 def change_user_role(
     project_id: int,
     role_change: RoleChange,

--- a/server/app/api/routers/trouble.py
+++ b/server/app/api/routers/trouble.py
@@ -55,12 +55,12 @@ def delete_trouble(
     return {"message": "Trouble deleted successfully"}
 
 
-@router.get("/project/{project_id}/troubles", response_model=TroubleListResponse)
-def get_project_troubles(
+@router.get("/trouble/{project_id}", response_model=TroubleListResponse)
+def get_trouble_list(
     project_id: int,
     query_params: TroubleListQuery = Depends(),
     service: TroubleService = Depends(get_trouble_service),
     username: str = Depends(get_current_username)
 ):
-    """프로젝트의 trouble 목록을 조회합니다."""
+    """프로젝트의 trouble 중 유저에게 권한이 있는 목록을 조회합니다."""
     return service.get_project_troubles(project_id, query_params, username)

--- a/server/app/api/routers/trouble.py
+++ b/server/app/api/routers/trouble.py
@@ -13,7 +13,7 @@ from app.api.deps import get_trouble_service, get_current_username
 router = APIRouter()
 
 
-@router.post("/trouble", response_model=Trouble)
+@router.post("/troubles", response_model=Trouble)
 def create_trouble(
     create_trouble_dto: TroubleCreate, 
     service: TroubleService = Depends(get_trouble_service),
@@ -23,7 +23,7 @@ def create_trouble(
     return service.create_trouble(create_trouble_dto, username)
 
 
-@router.get("/trouble/{trouble_id}", response_model=TroubleWithLogs)
+@router.get("/troubles/{trouble_id}", response_model=TroubleWithLogs)
 def get_trouble(
     trouble_id: int, 
     service: TroubleService = Depends(get_trouble_service),
@@ -33,7 +33,7 @@ def get_trouble(
     return service.get_trouble_by_id(trouble_id, username)
 
 
-@router.put("/trouble/{trouble_id}", response_model=Trouble)
+@router.put("/troubles/{trouble_id}", response_model=Trouble)
 def update_trouble(
     trouble_id: int, 
     trouble_update_dto: TroubleUpdate, 
@@ -44,7 +44,7 @@ def update_trouble(
     return service.update_trouble(trouble_id, trouble_update_dto, username)
 
 
-@router.delete("/trouble/{trouble_id}")
+@router.delete("/troubles/{trouble_id}")
 def delete_trouble(
     trouble_id: int, 
     service: TroubleService = Depends(get_trouble_service),
@@ -55,7 +55,7 @@ def delete_trouble(
     return {"message": "Trouble deleted successfully"}
 
 
-@router.get("/trouble/{project_id}", response_model=TroubleListResponse)
+@router.get("/troubles/{project_id}", response_model=TroubleListResponse)
 def get_trouble_list(
     project_id: int,
     query_params: TroubleListQuery = Depends(),

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -27,10 +27,10 @@ app.add_middleware(
 
 # 라우트 등록
 app.include_router(user.router, prefix="/api", tags=["users"])
-app.include_router(project.router, prefix="/api", tags=["project"])
+app.include_router(project.router, prefix="/api", tags=["projects"])
 app.include_router(pipeline.router, prefix="/api", tags=["pipeline"])
-app.include_router(log.router, prefix="/api", tags=["log"])
-app.include_router(trouble.router, prefix="/api", tags=["trouble"])
+app.include_router(log.router, prefix="/api", tags=["logs"])
+app.include_router(trouble.router, prefix="/api", tags=["troubles"])
 
 
 @app.get("/")

--- a/server/app/repositories/elasticsearch.py
+++ b/server/app/repositories/elasticsearch.py
@@ -1,5 +1,5 @@
 from fastapi import HTTPException
-from app.infra.database.elaticsearch import ElasticsearchClient
+from app.infra.database.elasticsearch import ElasticsearchClient
 from app.core.config.elastic_config import get_elastic_mappings
 from typing import List, Dict, Any
 from app.core.enums.log_filter import LogLevelFilter

--- a/server/test/trouble/test_api_create_trouble.py
+++ b/server/test/trouble/test_api_create_trouble.py
@@ -26,12 +26,12 @@ class TroubleAPITest:
         }
         
         print("=== Trouble 생성 API 테스트 ===")
-        print(f"요청 URL: {self.base_url}/api/trouble")
+        print(f"요청 URL: {self.base_url}/api/troubles")
         print(f"요청 데이터: {json.dumps(test_data, indent=2, ensure_ascii=False)}")
         
         try:
             response = requests.post(
-                f"{self.base_url}/api/trouble",
+                f"{self.base_url}/api/troubles",
                 json=test_data,
                 headers=self.headers,
                 timeout=30
@@ -114,7 +114,7 @@ class TroubleAPITest:
             
             try:
                 response = requests.post(
-                    f"{self.base_url}/api/trouble",
+                    f"{self.base_url}/api/troubles",
                     json=scenario["data"],
                     headers=self.headers,
                     timeout=10
@@ -144,7 +144,7 @@ def test_with_curl_command():
     }
     
     curl_command = f"""
-curl -X POST "http://localhost:8000/api/trouble" \\
+curl -X POST "http://localhost:8000/api/troubles" \\
      -H "Content-Type: application/json" \\
      -H "Accept: application/json" \\
      -d '{json.dumps(test_data, ensure_ascii=False)}'

--- a/server/test/trouble/test_api_delete_trouble.py
+++ b/server/test/trouble/test_api_delete_trouble.py
@@ -5,7 +5,7 @@ from app.main import app
 client = TestClient(app)
 
 def test_delete_trouble_api():
-    """DELETE /api/trouble/{trouble_id} API 테스트"""
+    """DELETE /api/troubles/{trouble_id} API 테스트"""
     
     print("=== DELETE trouble API 테스트 시작 ===")
     
@@ -14,7 +14,7 @@ def test_delete_trouble_api():
     print(f"\n1. 존재하지 않는 trouble 삭제 시도 (ID: {trouble_id})")
     
     response = client.delete(
-        f"/api/trouble/{trouble_id}",
+        f"/api/troubles/{trouble_id}",
         headers={"Authorization": "Bearer test-token"}
     )
     
@@ -31,7 +31,7 @@ def test_delete_trouble_api():
     print(f"\n2. 실제 trouble 삭제 시도 (ID: 1)")
     
     response = client.delete(
-        "/api/trouble/1",
+        "/api/troubles/1",
         headers={"Authorization": "Bearer test-token"}
     )
     

--- a/server/test/trouble/test_api_update_trouble.py
+++ b/server/test/trouble/test_api_update_trouble.py
@@ -5,7 +5,7 @@ from app.main import app
 client = TestClient(app)
 
 def test_update_trouble_api():
-    """PUT /api/trouble/{trouble_id} API 테스트"""
+    """PUT /api/troubles/{trouble_id} API 테스트"""
     
     print("=== UPDATE trouble API 테스트 시작 ===")
     
@@ -18,7 +18,7 @@ def test_update_trouble_api():
     }
     
     response = client.put(
-        "/api/trouble/1",
+        "/api/troubles/1",
         json=invalid_data,
         headers={"Authorization": "Bearer test-token"}
     )
@@ -40,7 +40,7 @@ def test_update_trouble_api():
     }
     
     response = client.put(
-        "/api/trouble/999",  # 존재하지 않는 ID
+        "/api/troubles/999",  # 존재하지 않는 ID
         json=valid_data,
         headers={"Authorization": "Bearer test-token"}
     )
@@ -57,7 +57,7 @@ def test_update_trouble_api():
     print("\n3. 유효한 데이터로 trouble 수정 테스트")
     
     response = client.put(
-        "/api/trouble/1",  # 실제 존재하는 trouble ID
+        "/api/troubles/1",  # 실제 존재하는 trouble ID
         json=valid_data,
         headers={"Authorization": "Bearer test-token"}
     )
@@ -93,7 +93,7 @@ def test_update_trouble_validation():
         "content": "새로운 분석 결과입니다. 로그 분석 결과 API 응답 시간이 평소보다 3배 느려진 것을 확인했습니다."
     }
     
-    response = client.put("/api/trouble/1", json=data, headers={"Authorization": "Bearer test-token"})
+    response = client.put("/api/troubles/1", json=data, headers={"Authorization": "Bearer test-token"})
     print(f"Status Code: {response.status_code}")
     print(f"Response: {response.json()}")
     
@@ -104,7 +104,7 @@ def test_update_trouble_validation():
         "is_shared": True
     }
     
-    response = client.put("/api/trouble/1", json=data, headers={"Authorization": "Bearer test-token"})
+    response = client.put("/api/troubles/1", json=data, headers={"Authorization": "Bearer test-token"})
     print(f"Status Code: {response.status_code}")
     print(f"Response: {response.json()}")
 


### PR DESCRIPTION
- 트러블슈팅 목록 조회
  - 엔드포인트 경로를 `/troubles/{project_id}`에서 `/trouble/{project_id}`로 변경
  - 함수명을 `get_troubles_list`에서 `get_trouble_list`로 변경
- elasticsearch 모듈 import 구문 수정
  - 이전 머지시 컨플릭트를 잘못 해결하여 수정
- 단수형 엔드포인트를 복수형으로 변경하여 REST API 설계 원칙 준수
  - /project → /projects로 모든 프로젝트 관련 엔드포인트 수정
  - /trouble → /troubles로 모든 트러블슈팅 관련 엔드포인트 수정
  - /log → /logs로 모든 로그 관련 엔드포인트 수정
