### PR TITLE
Refac[be]: Delete mysqlclient from poetry

### DIFF
--- a/server/poetry.lock
+++ b/server/poetry.lock
@@ -3440,4 +3440,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "1e10ad1e4099fc4889ba9ffb26ab73978410be528ab52463fcdfce1475b60077"
+content-hash = "382cd2e20c489137a1cab3c4970675cf2cad604fe0d1c81ba87e0bdf0b760c97"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "watchfiles (==1.0.4)",
     "websockets (==15.0.1)",
     "mysql (>=0.0.3,<0.0.4)",
-    "mysqlclient (>=2.2.7,<3.0.0)",
     "pandas (>=2.2.3,<3.0.0)",
     "numpy (>=2.2.4,<3.0.0)",
     "openai (>=1.72.0,<2.0.0)",
@@ -58,6 +57,8 @@ dependencies = [
     "langchain-community (>=0.3.27,<0.4.0)",
 ]
 
+[tool.poetry]
+package-mode = false
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]


### PR DESCRIPTION
- GPL-2.0-only인 mysqlclient 의존성을 제거
- poetry package mode를 명시적으로 비활성화