### PR TITLE
fix[be]: Update h11 to v0.16.0 for critical request issue

### DIFF
--- a/server/poetry.lock
+++ b/server/poetry.lock
@@ -936,14 +936,14 @@ test = ["objgraph", "psutil"]
 
 [[package]]
 name = "h11"
-version = "0.14.0"
+version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
-    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
+    {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
+    {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
 ]
 
 [[package]]
@@ -970,19 +970,19 @@ tests = ["pytest"]
 
 [[package]]
 name = "httpcore"
-version = "1.0.8"
+version = "1.0.9"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "httpcore-1.0.8-py3-none-any.whl", hash = "sha256:5254cf149bcb5f75e9d1b2b9f729ea4a4b883d1ad7379fc632b727cec23674be"},
-    {file = "httpcore-1.0.8.tar.gz", hash = "sha256:86e94505ed24ea06514883fd44d2bc02d90e77e7979c8eb71b90f41d364a1bad"},
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
 ]
 
 [package.dependencies]
 certifi = "*"
-h11 = ">=0.13,<0.15"
+h11 = ">=0.16"
 
 [package.extras]
 asyncio = ["anyio (>=4.0,<5.0)"]
@@ -3400,4 +3400,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "e0cf5b68fc7ccc621f6711467b8f4ed34f556c4d805b1463958235344c6b26de"
+content-hash = "fa891131955a931618f1a59771cbde8cbe8c9c391e9f306e8f9a655884bc40fe"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "dnspython (==2.7.0)",
     "email-validator (==2.2.0)",
     "fastapi (==0.115.12)",
-    "h11 (==0.14.0)",
+    "h11 (==0.16.0)",
     "httptools (==0.6.4)",
     "idna (==3.10)",
     "pip (==25.0.1)",


### PR DESCRIPTION
기존 h11 버전에서 Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling') 문제가 발생할 수 있음을 확인, 버전 업그레이드 진행